### PR TITLE
Fix db-srv docker image

### DIFF
--- a/infra/db-srv/Dockerfile
+++ b/infra/db-srv/Dockerfile
@@ -27,7 +27,6 @@ RUN mkdir /docker-entrypoint-initdb.d
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 ENV PG_MAJOR 9.4
-ENV PG_VERSION 9.4.4-1.pgdg80+1
 
 # maybe get it from offical distribution management
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
@@ -36,8 +35,8 @@ RUN apt-get update \
 	&& apt-get install -y postgresql-common \
 	&& sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf \
 	&& apt-get install -y \
-		postgresql-$PG_MAJOR=$PG_VERSION \
-		postgresql-contrib-$PG_MAJOR=$PG_VERSION \
+		postgresql-$PG_MAJOR \
+		postgresql-contrib-$PG_MAJOR \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql


### PR DESCRIPTION
The db-srv docker image is no longer building with the following message from `apt-install`:

    E: Version '9.4.4-1.pgdg80+1' for 'postgresql-9.4' was not found
    E: Version '9.4.4-1.pgdg80+1' for 'postgresql-contrib-9.4' was not found

This change removes the minor version and asks simply to install postgres 9.4.